### PR TITLE
This patch shows quest-starting items texture in Combuctor

### DIFF
--- a/Combuctor/item.lua
+++ b/Combuctor/item.lua
@@ -47,6 +47,10 @@ function ItemSlot:Create()
 	border:Hide()
 	item.border = border
 
+	-- prepare bang texture for quest-starting items
+	local questBorder = _G[item:GetName() .. 'IconQuestTexture']
+	item.questBorder = questBorder
+
 	--hack, make sure the cooldown model stays visible
 	item.cooldown = _G[item:GetName() .. 'Cooldown']
 
@@ -182,6 +186,17 @@ function ItemSlot:Update()
 	if not self:IsVisible() then return end
 
 	local texture, count, locked, quality, readable, lootable, link = self:GetItemSlotInfo()
+
+	-- set bang texture on quest-starting item
+	local isQuestItem, questId, isActive = GetContainerItemQuestInfo(self:GetBag(), self:GetID())
+	local questBorder = self.questBorder
+
+	if ( questId and not isActive) then
+		questBorder:SetTexture(TEXTURE_ITEM_QUEST_BANG)
+		questBorder:Show()
+	else
+		questBorder:Hide()
+	end
 
 	self:SetItem(link)
 	self:SetTexture(texture)

--- a/Combuctor/itemFrameEvents.lua
+++ b/Combuctor/itemFrameEvents.lua
@@ -25,8 +25,23 @@ function FrameEvents:OnEnable()
 	self:RegisterMessage('COMBUCTOR_SLOT_UPDATE', 'UpdateSlot')
 	self:RegisterEvent('ITEM_LOCK_CHANGED', 'UpdateSlotLock')
 
+	-- register questlog change event to update quest starting item texture 
+	self:RegisterEvent('QUEST_ACCEPTED', 'QuestLogUpdate')
+	self:RegisterEvent('UNIT_QUEST_LOG_CHANGED', 'QuestLogUpdate')
+
 	self:RegisterMessage('COMBUCTOR_BANK_OPENED', 'UpdateBankFrames')
 	self:RegisterMessage('COMBUCTOR_BANK_CLOSED', 'UpdateBankFrames')
+end
+
+function FrameEvents:QuestLogUpdate(msg, ...)
+	local arg1, arg2 = ...
+
+	if not (msg == 'UNIT_QUEST_LOG_CHANGED' and arg1 ~= 'player') then
+		-- just update everything
+		for f in self:GetFrames() do
+			f:Regenerate()
+		end
+	end
 end
 
 function FrameEvents:UpdateSlot(msg, ...)


### PR DESCRIPTION
Many codes are copy-pasted from default blizzard UI(3.3.x client). I'm not 100% sure about event listener codes.
Please review this patch and tell me if there's a problem.
