### PR TITLE
Bank Update Bag Fix 

### DIFF
--- a/core/inventoryEvents.lua
+++ b/core/inventoryEvents.lua
@@ -206,7 +206,7 @@ local function forEachBag(f, ...)
 	if not f then error('Usage: forEachBag(function, ...)', 2) end
 
 	if AtBank then
-		for bagId = 1, NUM_BAG_SLOTS + GetNumBankSlots() do
+		for bagId = -1, NUM_BAG_SLOTS + GetNumBankSlots() do
 			f(bagId, ...)
 		end
 	else


### PR DESCRIPTION
In inventoryEvents:updateItem(), item is always nil when it is in the main bank container so ITEM_SLOT_UPDATE is not fired when updated these slots.  This is because inventoryEvents:addItem() is never called on bagId -1 (which is the main bank container).  Having forEachBag start checking at bagId -1 when at the bank seems to correc the issue.
