### PR TITLE
Bug Fixes (Cooldowns and Greying Items [Mail/Loot Bags])

### DIFF
--- a/events/inventory.lua
+++ b/events/inventory.lua
@@ -228,26 +228,40 @@ do
 		self:RegisterEvent('PLAYERBANKSLOTS_CHANGED')
 		self:RegisterEvent('ZONE_CHANGED_NEW_AREA')
 		self:RegisterEvent('MAIL_SEND_INFO_UPDATE')
+		self:RegisterEvent('LOOT_OPENED')
+		self:RegisterEvent('LOOT_CLOSED')
 
 		UpdateBagSize(BACKPACK_CONTAINER)
 		forEachItem(BACKPACK_CONTAINER, updateItem)
 	end
 
 	function eventFrame:BAG_UPDATE(event, bagId, ...)
-		updateBags()
+		updateAllBagsTypeSize()
 		forEachItem(bagId, updateItem)
 	end
 	
 	function eventFrame:ZONE_CHANGED_NEW_AREA(event, ...)
-		updateBags()
+		updateAllBagsTypeSize()
 	end
 	
 	function eventFrame:MAIL_SEND_INFO_UPDATE(event, ...)
-		forEachBag(UpdateBagSize)
-		forEachBag(forEachItem, updateItem, ...)
+		updateAllBagsSizeItems()
 	end
 	
-	function updateBags()
+	function eventFrame:LOOT_OPENED(event, ...)
+		updateAllBagsSizeItems()
+	end
+	
+	function eventFrame:LOOT_CLOSED(event, ...)
+		updateAllBagsSizeItems()
+	end
+	
+	function updateAllBagsSizeItems()
+		forEachBag(UpdateBagSize)
+		forEachBag(forEachItem, updateItem)
+	end
+	
+	function updateAllBagsTypeSize()
 		forEachBag(UpdateBagType)
 		forEachBag(UpdateBagSize)
 	end


### PR DESCRIPTION
Patched a couple of bugs to do with greying out items when opened (loot bags) and when items are attached to mail.
Also patched cooldowns as they weren't showing until the bags were opened and then closed.

Not sure the patches are the best, but they work.

The below doesn't seem to work on at least one of my characters:
Also half-heartedly attempted to patch the shuffle by doing the same thing as for the above (not sure it works and definitely not fixing the root of the problem).
