### PR TITLE
Load retail template on retail, classic on classic.

### DIFF
--- a/Bagnonium.toc
+++ b/Bagnonium.toc
@@ -14,6 +14,7 @@
 ## Version: 12.0.18
 
 templates\shared.xml
-templates\classic.xml
+templates\retail.xml [AllowLoadGameType mainline]
+templates\classic.xml [AllowLoadGameType classic]
 templates\finish.xml
 src\main.xml


### PR DESCRIPTION
Currently classic template is being used everywhere, causing errors on retail due to missing button templates.

Fixes #213